### PR TITLE
chore: trigger claude code review (test, will not be merged)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+// claude-code-review trigger test (will not be merged)
 import { getCollection } from 'astro:content';
 import { SITE_TITLE, SITE_DESCRIPTION } from '@/consts';
 import Layout from '@/layouts/Layout.astro';


### PR DESCRIPTION
Add a one-line comment to src/pages/index.astro to exercise the claude-code-review.yml paths filter. This PR is opened only to verify the auto-review wiring and will be closed without merging.