### PR TITLE
chore: trigger pr review with sonnet 4.6

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ const allPosts = (await getCollection('blog'))
   .filter((post) => !post.data.draft)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
+// トップページに表示する記事数
 const postsPerPage = 3;
 const postList = allPosts.slice(0, postsPerPage);
 ---


### PR DESCRIPTION
Add a single comment on the home page to open a test PR and verify the new Sonnet 4.6 review cost vs the previous Opus 4.7 baseline.